### PR TITLE
Common API draft numero uno

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 * * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Neighborhood.jl
+++ b/src/Neighborhood.jl
@@ -1,0 +1,5 @@
+module Neighborhood
+
+include("api.jl")
+
+end  # module Neighborhood

--- a/src/api.jl
+++ b/src/api.jl
@@ -57,7 +57,8 @@ struct FixedAmount <: SearchType; k::Int; end
 """
     search(ss, query, st::SearchType; kwargs... ) → idxs, ds
 Perform a neighbor search in the search structure `ss` for the given
-`query` with search type `st`. Return the
+`query` with search type `st`. Return the indices of the neighbors (in the original data)
+and the distances from the query.
 
 Package-specific keywords could be possible, see the specific nearest neighbor package
 for details.

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,0 +1,60 @@
+#=
+This file defines the common API for finding neighbors in Julia. For a package
+to participate in this common API it should extend the following methods:
+
+Let `SS` be your search structure. Then define:
+
+* searchstructure(::T, data, metric)  (this gives `ss`)
+* search(ss::SS, query, ::SearchType) (preferably for both SearchType types)
+
+=#
+export FixedRange, FixedAmount, SearchType
+export search, inrange, knn
+export searchstructure
+
+abstract type SearchType end
+
+"""
+    FixedRange(r) <: SearchType
+Search type representing all neighbors with distance `≤ r` from the query.
+"""
+struct FixedRange{R} <: SearchType; r::R; end
+
+"""
+    FixedAmount(k) <: SearchType
+Search type representing the `k` nearest neighbors of the query.
+"""
+struct FixedAmount <: SearchType; k::Int; end
+
+"""
+    search(ss, query, st::SearchType; kwargs... ) → neighbors
+Perform a neighbor search in the search structure `ss` for the given
+`query` with search type `st`.
+
+Structure-specific keywords could be possible, see the specific nearest neighbor package
+for details.
+"""
+function search end
+
+"""
+    inrange(ss, query, r; kwargs...) → neighbors
+Find all neighbors of the `query` with distance `≤ r` in the search structure `ss`.
+If none exist, and empty vector (of the same type) is returned.
+"""
+inrange(a, b, r; kwargs...) = search(a, b, FixedRange(r); kwargs...)
+
+"""
+    knn(ss, query, k::Integer; kwargs...) → neighbors
+Find the `k` nearest neighbors (or approximate ones, depending on `ss`) of the `query`
+in the search structure `ss`.
+"""
+knn(a, b, k::Integer; kwargs...) = search(a, b, FixedAmount(k); kwargs...)
+
+
+"""
+    searchstructure(T, data, metric; kwargs...) → st
+Create a search structure `st` of type `T` (e.g. `KDTree, BallTree` etc.) based on the
+given `data` and `metric`. The data types and supported metric types are package-specific,
+but typically all subtypes of `<:Metric` from Distances.jl are supported.
+"""
+function searchstructure end

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,17 +2,26 @@
 This file defines the common API for finding neighbors in Julia. For a package
 to participate in this common API it should extend the following methods:
 
-Let `SS` be your search structure. Then define:
+Let `SS` be your search structure. Make sure that this `SS` is a subtype of
+`SearchStrucutre`. Then define:
 
-* searchstructure(::T, data, metric)  (this gives `ss`)
+* searchstructure(::T, data, metric)  (this gives `ss`, an instance of `SS`)
 * search(ss::SS, query, ::SearchType) (preferably for both SearchType types)
-
 =#
+
 export FixedRange, FixedAmount, SearchType
 export search, inrange, knn
-export searchstructure
+export searchstructure, SearchStructure
 
+"""
+Supertype of all possible search types of the Neighborhood.jl common API.
+"""
 abstract type SearchType end
+
+"""
+Supertype of all structures that participate in the Neighborhood.jl common API.
+"""
+abstract type SearchStructure end
 
 """
     FixedRange(r) <: SearchType
@@ -27,14 +36,16 @@ Search type representing the `k` nearest neighbors of the query.
 struct FixedAmount <: SearchType; k::Int; end
 
 """
-    search(ss, query, st::SearchType; kwargs... ) → neighbors
+    search(ss::SearchStructure, query, st::SearchType; kwargs... ) → neighbors
 Perform a neighbor search in the search structure `ss` for the given
 `query` with search type `st`.
 
-Structure-specific keywords could be possible, see the specific nearest neighbor package
+Package-specific keywords could be possible, see the specific nearest neighbor package
 for details.
 """
-function search end
+function search(ss::SearchStructure, query, st::SearchType; kwargs...)
+    error("`search` is not implemented for this combination of input types.")
+end
 
 """
     inrange(ss, query, r; kwargs...) → neighbors
@@ -53,8 +64,39 @@ knn(a, b, k::Integer; kwargs...) = search(a, b, FixedAmount(k); kwargs...)
 
 """
     searchstructure(T, data, metric; kwargs...) → st
-Create a search structure `st` of type `T` (e.g. `KDTree, BallTree` etc.) based on the
+Create a search structure `st` of type `T` (e.g. `KDTree, BKTree` etc.) based on the
 given `data` and `metric`. The data types and supported metric types are package-specific,
 but typically all subtypes of `<:Metric` from Distances.jl are supported.
 """
-function searchstructure end
+function searchstructure(::Type{T}, data, metric; kwargs...) where {T<:SearchStructure}
+    error("Given type $(T) has not implemented the Neighborhood.jl public API.")
+end
+
+
+##########################################################################################
+# Delete and insertion: mutable search structures
+##########################################################################################
+
+"""
+    insert!(ss::SearchStructure, index, point)
+Insert a new `point` to the search structure `ss` at the given `index`
+(similarly with `Base.insert!`).
+
+The `index` type is package-specific.
+"""
+function Base.insert!(ss::T, index, point) where {T <: SearchStructure}
+    error("Given type $(T) has either not implemented the Neighborhood.jl public API "*
+          "or uses an immutable search structure.")
+end
+
+"""
+    deleteat!(ss::SearchStructure, index)
+Remove the point of the search structure specified by the given `index`
+(similarly with `Base.deletat!`).
+
+The `index` type is package-specific.
+"""
+function Base.deleteat!(ss::T, index) where {T <: SearchStructure}
+    error("Given type $(T) has either not implemented the Neighborhood.jl public API "*
+          "or uses an immutable search structure.")
+end

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,11 +2,13 @@
 This file defines the common API for finding neighbors in Julia. For a package
 to participate in this common API it should extend the following methods:
 
-Let `SS` be your search structure. Make sure that this `SS` is a subtype of
+Let `T` be the type of your search structure. Make sure that this `SS` is a subtype of
 `SearchStrucutre`. Then define:
 
-* searchstructure(::T, data, metric)  (this gives `ss`, an instance of `SS`)
-* search(ss::SS, query, ::SearchType) (preferably for both SearchType types)
+* searchstructure(::Type{T}, data, metric)  (this gives `ss`)
+* search(ss::T, query, ::SearchType) (preferably for both SearchType types)
+
+Notice that ::Type{T} only needs the supertype, e.g. `KDTree`, without the type-parameters.
 =#
 
 export FixedRange, FixedAmount, SearchType
@@ -18,10 +20,18 @@ Supertype of all possible search types of the Neighborhood.jl common API.
 """
 abstract type SearchType end
 
+
 """
-Supertype of all structures that participate in the Neighborhood.jl common API.
+    searchstructure(T, data, metric; kwargs...) → st
+Create a search structure `st` of type `T` (e.g. `KDTree, BKTree` etc.) based on the
+given `data` and `metric`. The data types and supported metric types are package-specific,
+but typically all subtypes of `<:Metric` from Distances.jl are supported.
 """
-abstract type SearchStructure end
+function searchstructure(::Type{T}, data::D, metric::M; kwargs...) where
+                         {T, D, M}
+    error("Given type $(T) has not implemented the Neighborhood.jl public API "*
+          "for data type $(D) and metric type $(M).")
+end
 
 """
     FixedRange(r) <: SearchType
@@ -36,14 +46,14 @@ Search type representing the `k` nearest neighbors of the query.
 struct FixedAmount <: SearchType; k::Int; end
 
 """
-    search(ss::SearchStructure, query, st::SearchType; kwargs... ) → neighbors
+    search(ss, query, st::SearchType; kwargs... ) → neighbors
 Perform a neighbor search in the search structure `ss` for the given
 `query` with search type `st`.
 
 Package-specific keywords could be possible, see the specific nearest neighbor package
 for details.
 """
-function search(ss::SearchStructure, query, st::SearchType; kwargs...)
+function search(ss, query, st::SearchType; kwargs...)
     error("`search` is not implemented for this combination of input types.")
 end
 
@@ -62,41 +72,31 @@ in the search structure `ss`.
 knn(a, b, k::Integer; kwargs...) = search(a, b, FixedAmount(k); kwargs...)
 
 
-"""
-    searchstructure(T, data, metric; kwargs...) → st
-Create a search structure `st` of type `T` (e.g. `KDTree, BKTree` etc.) based on the
-given `data` and `metric`. The data types and supported metric types are package-specific,
-but typically all subtypes of `<:Metric` from Distances.jl are supported.
-"""
-function searchstructure(::Type{T}, data, metric; kwargs...) where {T<:SearchStructure}
-    error("Given type $(T) has not implemented the Neighborhood.jl public API.")
-end
-
 
 ##########################################################################################
 # Delete and insertion: mutable search structures
 ##########################################################################################
 
 """
-    insert!(ss::SearchStructure, index, point)
+    insert!(ss, index, point)
 Insert a new `point` to the search structure `ss` at the given `index`
 (similarly with `Base.insert!`).
 
 The `index` type is package-specific.
 """
-function Base.insert!(ss::T, index, point) where {T <: SearchStructure}
+function Base.insert!(ss::T, index, point) where {T}
     error("Given type $(T) has either not implemented the Neighborhood.jl public API "*
           "or uses an immutable search structure.")
 end
 
 """
-    deleteat!(ss::SearchStructure, index)
+    deleteat!(ss, index)
 Remove the point of the search structure specified by the given `index`
 (similarly with `Base.deletat!`).
 
 The `index` type is package-specific.
 """
-function Base.deleteat!(ss::T, index) where {T <: SearchStructure}
+function Base.deleteat!(ss::T, index) where {T}
     error("Given type $(T) has either not implemented the Neighborhood.jl public API "*
           "or uses an immutable search structure.")
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,9 +1,8 @@
 #=
-This file defines the common API for finding neighbors in Julia. For a package
-to participate in this common API it should extend the following methods:
+This file defines the common API for finding neighbors in Julia.
 
-Let `T` be the type of your search structure. Make sure that this `SS` is a subtype of
-`SearchStrucutre`. Then define:
+Let `T` be the type of the search structure of your package.
+To participate in this common API you should extend the following methods:
 
 * searchstructure(::Type{T}, data, metric) → `ss`
 * search(ss::T, query, ::SearchType) → `idxs, ds`

--- a/src/api.jl
+++ b/src/api.jl
@@ -35,7 +35,7 @@ abstract type SearchType end
     searchstructure(T, data, metric; kwargs...) → st
 Create a search structure `st` of type `T` (e.g. `KDTree, BKTree` etc.) based on the
 given `data` and `metric`. The data types and supported metric types are package-specific,
-but typically all subtypes of `<:Metric` from Distances.jl are supported.
+but typical choices are subtypes of `<:Metric` from Distances.jl.
 """
 function searchstructure(::Type{T}, data::D, metric::M; kwargs...) where
                          {T, D, M}
@@ -68,16 +68,14 @@ function search(ss, query, st::SearchType; kwargs...)
 end
 
 """
-    inrange(ss, query, r; kwargs...) → neighbors
-Find all neighbors of the `query` with distance `≤ r` in the search structure `ss`.
-If none exist, and empty vector (of the same type) is returned.
+    inrange(ss, query, r; kwargs...)
+Basically [`search`](@ref) for `FixedRange(r)` search type.
 """
 inrange(a, b, r; kwargs...) = search(a, b, FixedRange(r); kwargs...)
 
 """
-    knn(ss, query, k::Integer; kwargs...) → neighbors
-Find the `k` nearest neighbors (or approximate ones, depending on `ss`) of the `query`
-in the search structure `ss`.
+    knn(ss, query, k::Integer; kwargs...)
+Basically [`search`](@ref) for `FixedAmount(k)` search type.
 """
 knn(a, b, k::Integer; kwargs...) = search(a, b, FixedAmount(k); kwargs...)
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -5,11 +5,21 @@ to participate in this common API it should extend the following methods:
 Let `T` be the type of your search structure. Make sure that this `SS` is a subtype of
 `SearchStrucutre`. Then define:
 
-* searchstructure(::Type{T}, data, metric)  (this gives `ss`)
-* search(ss::T, query, ::SearchType) (preferably for both SearchType types)
+* searchstructure(::Type{T}, data, metric) → `ss`
+* search(ss::T, query, ::SearchType) → `idxs, ds`
+
+`search` returns the indices of the neighbors (in the original `data`) and the distances from
+the query.
 
 Notice that ::Type{T} only needs the supertype, e.g. `KDTree`, without the type-parameters.
 =#
+
+# TODO: Discuss whether `search` should return:
+# * IDXS+DISTANCES
+# * POINTS+DISTANCES
+# * only IDXS
+# TODO: Discuss if it is worth it (or just too much effort) to implement 2 functions:
+# one returning only indices, one indices and distances...?
 
 export FixedRange, FixedAmount, SearchType
 export search, inrange, knn
@@ -46,9 +56,9 @@ Search type representing the `k` nearest neighbors of the query.
 struct FixedAmount <: SearchType; k::Int; end
 
 """
-    search(ss, query, st::SearchType; kwargs... ) → neighbors
+    search(ss, query, st::SearchType; kwargs... ) → idxs, ds
 Perform a neighbor search in the search structure `ss` for the given
-`query` with search type `st`.
+`query` with search type `st`. Return the
 
 Package-specific keywords could be possible, see the specific nearest neighbor package
 for details.

--- a/tests/mock_implementation.jl
+++ b/tests/mock_implementation.jl
@@ -1,0 +1,60 @@
+using Neighborhood, NearestNeighbors, VPTrees, Distances, StaticArrays, Random
+
+Random.seed!(5)
+data = [rand(SVector{3}) for i in 1:1000]
+query = SVector(0.99, 0.99, 0.99)
+r = 0.1
+k = 5
+
+############# NearestNeighbors version
+
+function Neighborhood.searchstructure(::Type{KDTree}, data, metric; kwargs...)
+    return KDTree(data, metric; kwargs...)
+end
+
+function Neighborhood.search(tree::KDTree, query, K::FixedAmount; kwargs...)
+    return NearestNeighbors.knn(tree, query, K.k; kwargs...)
+end
+
+function Neighborhood.search(tree::KDTree, query, R::FixedRange; kwargs...)
+    idxs = NearestNeighbors.inrange(tree, query, R.r; kwargs...)
+    if tree.reordered # TODO: I am actually not sure how to do this...
+        ds = [evaluate(tree.metric, query, tree.data[tree.indices[i]]) for i in idxs]
+    else
+        ds = [evaluate(tree.metric, query, tree.data[i]) for i in idxs]
+    end
+    return idxs, ds
+end
+
+
+tree1 = searchstructure(KDTree, data, Euclidean(); reorder = true)
+tree2 = searchstructure(KDTree, data, Euclidean(); reorder = false)
+
+inn, dsnn = search(tree, query, FixedAmount(k))
+
+
+idxs1, ds1 = search(tree1, query, FixedRange(r))
+all(d -> d ≤ r, ds)
+# For non-reordered trees it works
+idxs2, ds2 = search(tree2, query, FixedRange(r))
+all(d -> d ≤ r, ds)
+
+############# VPTrees version
+function Neighborhood.searchstructure(::Type{VPTree}, data, metric)
+    VPTree(data, metric)
+end
+
+function Neighborhood.search(tree::VPTree, query, K::FixedAmount)
+    idxs = VPTrees.find_nearest(tree, query, K.k)
+    return idxs, [tree.metric(query, tree.data[i]) for i in idxs]
+end
+
+function Neighborhood.search(tree::VPTree, query, R::FixedRange)
+    idxs = VPTrees.find(tree, query, R.r)
+    return idxs, [tree.metric(query, tree.data[i]) for i in idxs]
+end
+
+f(a, b) = evaluate(Euclidean(), a, b)
+vtree = searchstructure(VPTree, data, f)
+
+idxs, ds = search(vtree, query, FixedAmount(k))


### PR DESCRIPTION
Result of the discussion of #1. @JonasIsensee @zgornel @altre @dillondaudert let's talk :D 

Main point for me is the return type of `search`. Seems that most packages actually return _only_ indices, and not distances.

---

@KristofferC seems to me that the discussion here is very relevant for NearestNeighbors.jl . But if you do not want to participate (without having to justify why), it is still best to let us know, so that we think about how to proceed with NearestNeighbors.jl.