### PR TITLE
Fix incorrect index variable in bulksearch

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -121,7 +121,7 @@ function bulksearch(ss, queries, t, skip; kwargs...)
     sizehint!(idxs, length(queries))
     sizehint!(ds, length(queries))
     for j in 2:length(queries)
-        sk = k -> skip(i, k)
+        sk = k -> skip(j, k)
         i, d = search(ss, queries[j], t, sk; kwargs...)
         push!(idxs, i); push!(ds, d)
     end


### PR DESCRIPTION
`bulksearch` method with `skip` argument subbed an `i` for a `j`, fixed.