### PR TITLE
Export inrangecount from NearestNeighbors.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Neighborhood"
 uuid = "645ca80c-8b79-4109-87ea-e1f58159d116"
 authors = ["Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/JuliaNeighbors/Neighborhood.jl.git"
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,7 @@ Neighborhood.getmetric
 search
 isearch
 inrange
+inrangecount
 knn
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,6 @@ knn
 ```@docs
 SearchType
 WithinRange
-WithinRangeCount
 NeighborNumber
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,6 +34,7 @@ knn
 ```@docs
 SearchType
 WithinRange
+WithinRangeCount
 NeighborNumber
 ```
 

--- a/src/Neighborhood.jl
+++ b/src/Neighborhood.jl
@@ -1,7 +1,8 @@
 module Neighborhood
 using Distances
+using NearestNeighbors: inrangecount
 export Euclidean, Chebyshev, Cityblock, Minkowski
-
+export inrangecount
 
 include("util.jl")
 include("api.jl")

--- a/src/Neighborhood.jl
+++ b/src/Neighborhood.jl
@@ -1,8 +1,6 @@
 module Neighborhood
 using Distances
-using NearestNeighbors: inrangecount
 export Euclidean, Chebyshev, Cityblock, Minkowski
-export inrangecount
 
 include("util.jl")
 include("api.jl")

--- a/src/api.jl
+++ b/src/api.jl
@@ -33,6 +33,13 @@ Search type representing all neighbors with distance `≤ r` from the query
 struct WithinRange{R} <: SearchType; r::R; end
 
 """
+    WithinRangeCount(r::Real) <: SearchType
+Search type representing the number of neighbors with distance `≤ r` from the query
+(according to the search structure's metric).
+"""
+struct WithinRangeCount{R} <: SearchType; r::R; end
+
+"""
     NeighborNumber(k::Int) <: SearchType
 Search type representing the `k` nearest neighbors of the query (or approximate
 neighbors, depending on the search structure).
@@ -88,11 +95,11 @@ isearch(args...; kwargs...) = search(args...; kwargs...)[1]
 inrange(a, b, r, args...; kwargs...) = search(a, b, WithinRange(r), args...; kwargs...)
 
 """
-    inrangecount(tree, point, r)
+    inrangecount(ss, query, r; kwargs....)
 
-Count how many points in a pre-computed `tree` lie within radius `r` of `point`.
+[`search`](@ref) for `WithinRangeCount(r)` search type.
 """
-inrangecount(tree, point, r) = NearestNeighbors.inrangecount(tree, point, r)
+inrangecount(tree, point, r) = search(tree, point, r; kwargs...)
 
 """
     knn(ss, query, k::Int [, skip]; kwargs...)

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,11 +1,12 @@
 "`alwaysfalse(ags...; kwargs...) = false`"
 alwaysfalse(ags...; kwargs...) = false
 
-export WithinRange, NeighborNumber, SearchType
+import NearestNeighbors: inrangecount
+
+export WithinRange, WithinRangeCount, NeighborNumber, SearchType
 export searchstructure
 export search, isearch, inrange, knn, inrangecount
 export bulksearch, bulkisearch
-import NearestNeighbors
 
 """
 Supertype of all possible search types of the Neighborhood.jl common API.
@@ -99,7 +100,7 @@ inrange(a, b, r, args...; kwargs...) = search(a, b, WithinRange(r), args...; kwa
 
 [`search`](@ref) for `WithinRangeCount(r)` search type.
 """
-inrangecount(tree, point, r) = search(tree, point, r; kwargs...)
+inrangecount(a, b, r; kwargs...) = search(a, b, r; kwargs...)
 
 """
     knn(ss, query, k::Int [, skip]; kwargs...)

--- a/src/api.jl
+++ b/src/api.jl
@@ -3,8 +3,9 @@ alwaysfalse(ags...; kwargs...) = false
 
 export WithinRange, NeighborNumber, SearchType
 export searchstructure
-export search, isearch, inrange, knn
+export search, isearch, inrange, knn, inrangecount
 export bulksearch, bulkisearch
+import NearestNeighbors
 
 """
 Supertype of all possible search types of the Neighborhood.jl common API.
@@ -85,6 +86,13 @@ isearch(args...; kwargs...) = search(args...; kwargs...)[1]
 [`search`](@ref) for `WithinRange(r)` search type.
 """
 inrange(a, b, r, args...; kwargs...) = search(a, b, WithinRange(r), args...; kwargs...)
+
+"""
+    inrangecount(tree, point, r)
+
+Count how many points in a pre-computed `tree` lie within radius `r` of `point`.
+"""
+inrangecount(tree, point, r) = NearestNeighbors.inrangecount(tree, point, r)
 
 """
     knn(ss, query, k::Int [, skip]; kwargs...)

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,8 +1,6 @@
 "`alwaysfalse(ags...; kwargs...) = false`"
 alwaysfalse(ags...; kwargs...) = false
 
-import NearestNeighbors: inrangecount
-
 export WithinRange, NeighborNumber, SearchType
 export searchstructure
 export search, isearch, inrange, knn, inrangecount

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -29,6 +29,10 @@ function Neighborhood.search(tree::KDTree, query, t::WithinRange, skip=alwaysfal
     return idxs, ds
 end
 
+function Neighborhood.search(tree::KDTree, query, t::WithinRangeCount)
+    return NearestNeighbors.inrangecount(tree, query, t.r)
+end
+
 function _NN_get_ds(tree::KDTree, query, idxs)
     if tree.reordered
         ds = [

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -29,8 +29,8 @@ function Neighborhood.search(tree::KDTree, query, t::WithinRange, skip=alwaysfal
     return idxs, ds
 end
 
-function Neighborhood.search(tree::KDTree, query, t::WithinRangeCount)
-    return NearestNeighbors.inrangecount(tree, query, t.r)
+function Neighborhood.inrangecount(tree::KDTree, query, r::Real)
+    return NearestNeighbors.inrangecount(tree, query, r)
 end
 
 function _NN_get_ds(tree::KDTree, query, idxs)

--- a/test/nearestneighbors.jl
+++ b/test/nearestneighbors.jl
@@ -89,7 +89,7 @@ end
     tree = KDTree(x, Euclidean())
     # Slightly extend bounds to check for both none and all neighbors.
     rmins = [WithinRangeCount(min_ds[i] * 0.99) for (i, xᵢ) in enumerate(x)]
-    rmaxs = [WithinRangeCount(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)
+    rmaxs = [WithinRangeCount(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)]
     ns_min = [inrangecount(tree, xᵢ, rmins[i]) - 1 for (i, xᵢ) in enumerate(x)]
     ns_max = [inrangecount(tree, xᵢ, rmaxs[i]) - 1 for (i, xᵢ) in enumerate(x)]
     @test all(ns_min .== 0)

--- a/test/nearestneighbors.jl
+++ b/test/nearestneighbors.jl
@@ -88,15 +88,15 @@ end
     max_ds = maximum.(ds)
     tree = KDTree(x, Euclidean())
     # Slightly extend bounds to check for both none and all neighbors.
-    rmins = [WithinRangeCount(min_ds[i] * 0.99) for (i, xᵢ) in enumerate(x)]
-    rmaxs = [WithinRangeCount(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)]
+    rmins = [(min_ds[i] * 0.99) for (i, xᵢ) in enumerate(x)]
+    rmaxs = [(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)]
     ns_min = [inrangecount(tree, xᵢ, rmins[i]) - 1 for (i, xᵢ) in enumerate(x)]
     ns_max = [inrangecount(tree, xᵢ, rmaxs[i]) - 1 for (i, xᵢ) in enumerate(x)]
     @test all(ns_min .== 0)
     @test all(ns_max .== N - 1)
 
     # For each point, there should be exactly three neighbors within these radii
-    r3s = [WithinRangeCount(ds[i][3] * 1.01) for (i, xᵢ) in enumerate(x)]
+    r3s = [(ds[i][3] * 1.01) for (i, xᵢ) in enumerate(x)]
     ns_3s = [inrangecount(tree, xᵢ, r3s[i]) - 1 for (i, xᵢ) in enumerate(x)]
     @test all(ns_3s .== 3)
 end

--- a/test/nearestneighbors.jl
+++ b/test/nearestneighbors.jl
@@ -1,3 +1,5 @@
+using Distances
+
 @testset "KDTree" begin
 
 tree1 = searchstructure(KDTree, data, Euclidean(); reorder = true)
@@ -75,6 +77,31 @@ vec_of_idxs, vec_of_ds = bulksearch(tree1, queries, WithinRange(0.002), theiler2
 for (x, y) in zip(vec_of_idxs, vec_of_ds)
     @test isempty(x)
     @test isempty(y)
+end
+
+@testset "inrangecount" begin
+    N = 10
+    x = [rand(SVector{3}) for i = 1:N]
+    D = pairwise(Euclidean(), x)
+    ds = [sort(D[setdiff(1:N, i), i]) for i = 1:N]
+    min_ds = minimum.(ds)
+    max_ds = maximum.(ds)
+    tree = KDTree(x, Euclidean())
+    # Slightly extend bounds to check for both none and all neighbors.
+    rmins = [WithinRangeCount(min_ds[i] * 0.99) for (i, xᵢ) in enumerate(x)]
+    rmaxs = [WithinRangeCount(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)]
+
+    # For each point, there should be exactly three neighbors within these radii
+    r3s = [WithinRangeCount(ds[i][3] * 1.01) for (i, xᵢ) in enumerate(x)]
+
+    # Subtract one to exclude point itself
+    ns_min = [inrangecount(tree, xᵢ, rmins[i]) - 1 for (i, xᵢ) in enumerate(x)]
+    ns_max = [inrangecount(tree, xᵢ, rmaxs[i]) - 1 for (i, xᵢ) in enumerate(x)]
+    @test all(ns_min .== 0)
+    @test all(ns_max .== N - 1)
+
+    ns_3s = [inrangecount(tree, xᵢ, r3s[i]) - 1 for (i, xᵢ) in enumerate(x)]
+    @test all(ns_3s .== 3)
 end
 
 end

--- a/test/nearestneighbors.jl
+++ b/test/nearestneighbors.jl
@@ -89,17 +89,14 @@ end
     tree = KDTree(x, Euclidean())
     # Slightly extend bounds to check for both none and all neighbors.
     rmins = [WithinRangeCount(min_ds[i] * 0.99) for (i, xᵢ) in enumerate(x)]
-    rmaxs = [WithinRangeCount(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)]
-
-    # For each point, there should be exactly three neighbors within these radii
-    r3s = [WithinRangeCount(ds[i][3] * 1.01) for (i, xᵢ) in enumerate(x)]
-
-    # Subtract one to exclude point itself
+    rmaxs = [WithinRangeCount(max_ds[i] * 1.01) for (i, xᵢ) in enumerate(x)
     ns_min = [inrangecount(tree, xᵢ, rmins[i]) - 1 for (i, xᵢ) in enumerate(x)]
     ns_max = [inrangecount(tree, xᵢ, rmaxs[i]) - 1 for (i, xᵢ) in enumerate(x)]
     @test all(ns_min .== 0)
     @test all(ns_max .== N - 1)
 
+    # For each point, there should be exactly three neighbors within these radii
+    r3s = [WithinRangeCount(ds[i][3] * 1.01) for (i, xᵢ) in enumerate(x)]
     ns_3s = [inrangecount(tree, xᵢ, r3s[i]) - 1 for (i, xᵢ) in enumerate(x)]
     @test all(ns_3s .== 3)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Test, Neighborhood, StaticArrays, Random, Distances
 using Neighborhood: datatype, getmetric, bruteforcesearch
 using Neighborhood.Testing
 
-
 Random.seed!(54525)
 data = [rand(SVector{3}) for i in 1:1000]
 query = SVector(0.99, 0.99, 0.99)
@@ -17,8 +16,9 @@ theiler2 = Theiler(2, nidxs)
 r = 0.1
 k = 5
 
-
-@testset "Utils" begin include("util.jl") end
-@testset "Neighborhood.Testing" begin include("Testing.jl") end
-@testset "Brute force" begin include("bruteforce.jl") end
-include("nearestneighbors.jl")
+@testset "Neighborhood" begin
+    @testset "Utils" begin include("util.jl") end
+    @testset "Neighborhood.Testing" begin include("Testing.jl") end
+    @testset "Brute force" begin include("bruteforce.jl") end
+    @testset "NearestNeighbors" begin include("nearestneighbors.jl") end
+end


### PR DESCRIPTION
Export `inrangecount` from NearestNeighbors.jl, as discussed in https://github.com/JuliaDynamics/Entropies.jl/pull/71#discussion_r1002435920 and in #16.

Is this approach ok? I'm not sure whether to export `inrangecount` directly, or override it with its own docstring here. 