### PR TITLE
docs: replace violent idiom with neutral wording

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Neighborhood"
 uuid = "645ca80c-8b79-4109-87ea-e1f58159d116"
 authors = ["Datseris <datseris.george@gmail.com>"]
 repo = "https://github.com/JuliaNeighbors/Neighborhood.jl.git"
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -46,7 +46,7 @@ and returns `true` if this neighbor should be skipped.
 In the second version, `skip` takes two arguments `skip(i, j)` where now `j` is simply
 the index of the query that we are currently searching for.
 
-You can kill two birds with one stone and directly implement one method:
+You can solve two goals at once and directly implement one method:
 ```julia
 search(ss::S, query, t::SearchType, skip = alwaysfalse; kwargs...)
 ```


### PR DESCRIPTION
## Summary
- replace the phrase `kill two birds with one stone` with `solve two goals at once` in `docs/src/dev.md`

## Why
This keeps the same technical meaning while using neutral language.

No behavior or API changes.
